### PR TITLE
Add network direction processor  code review

### DIFF
--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_array.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_array.ts
@@ -62,7 +62,7 @@ export const UseArray = ({
   const uniqueId = useRef(0);
 
   const form = useFormContext();
-  const { __getFieldDefaultValue } = form;
+  const { getFieldDefaultValue } = form;
 
   const getNewItemAtIndex = useCallback(
     (index: number): ArrayItem => ({
@@ -75,7 +75,7 @@ export const UseArray = ({
 
   const fieldDefaultValue = useMemo<ArrayItem[]>(() => {
     const defaultValues = readDefaultValueOnForm
-      ? (__getFieldDefaultValue(path) as any[])
+      ? (getFieldDefaultValue(path) as any[])
       : undefined;
 
     const getInitialItemsFromValues = (values: any[]): ArrayItem[] =>
@@ -88,13 +88,7 @@ export const UseArray = ({
     return defaultValues
       ? getInitialItemsFromValues(defaultValues)
       : new Array(initialNumberOfItems).fill('').map((_, i) => getNewItemAtIndex(i));
-  }, [
-    path,
-    initialNumberOfItems,
-    readDefaultValueOnForm,
-    __getFieldDefaultValue,
-    getNewItemAtIndex,
-  ]);
+  }, [path, initialNumberOfItems, readDefaultValueOnForm, getFieldDefaultValue, getNewItemAtIndex]);
 
   // Create a new hook field with the "isIncludedInOutput" set to false so we don't use its value to build the final form data.
   // Apart from that the field behaves like a normal field and is hooked into the form validation lifecycle.

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/components/use_field.tsx
@@ -59,8 +59,7 @@ function UseFieldComp<T = unknown, FormType = FormData, I = T>(props: Props<T, F
   } else {
     if (readDefaultValueOnForm) {
       // Read the field initial value from the "defaultValue" object passed to the form
-      fieldConfig.initialValue =
-        (form.__getFieldDefaultValue(path) as T) ?? fieldConfig.defaultValue;
+      fieldConfig.initialValue = (form.getFieldDefaultValue(path) as T) ?? fieldConfig.defaultValue;
     }
   }
 

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_form.ts
@@ -257,11 +257,6 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
     [getFormData$, updateFormData$, fieldsToArray]
   );
 
-  const getFieldDefaultValue: FormHook<T, I>['__getFieldDefaultValue'] = useCallback(
-    (fieldName) => get(defaultValueDeserialized.current, fieldName),
-    []
-  );
-
   const readFieldConfigFromSchema: FormHook<T, I>['__readFieldConfigFromSchema'] = useCallback(
     (fieldName) => {
       const config = (get(schema ?? {}, fieldName) as FieldConfig) || {};
@@ -337,6 +332,11 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
   }, []);
 
   const getFields: FormHook<T, I>['getFields'] = useCallback(() => fieldsRefs.current, []);
+
+  const getFieldDefaultValue: FormHook<T, I>['getFieldDefaultValue'] = useCallback(
+    (fieldName) => get(defaultValueDeserialized.current, fieldName),
+    []
+  );
 
   const submit: FormHook<T, I>['submit'] = useCallback(
     async (e) => {
@@ -430,6 +430,7 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
       setFieldValue,
       setFieldErrors,
       getFields,
+      getFieldDefaultValue,
       getFormData,
       getErrors,
       reset,
@@ -438,7 +439,6 @@ export function useForm<T extends FormData = FormData, I extends FormData = T>(
       __updateFormDataAt: updateFormDataAt,
       __updateDefaultValueAt: updateDefaultValueAt,
       __readFieldConfigFromSchema: readFieldConfigFromSchema,
-      __getFieldDefaultValue: getFieldDefaultValue,
       __addField: addField,
       __removeField: removeField,
       __validateFields: validateFields,

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/types.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/types.ts
@@ -36,6 +36,8 @@ export interface FormHook<T extends FormData = FormData, I extends FormData = T>
   setFieldErrors: (fieldName: string, errors: ValidationError[]) => void;
   /** Access the fields on the form. */
   getFields: () => FieldsMap;
+  /** Access the defaultValue for a specific field */
+  getFieldDefaultValue: (path: string) => unknown;
   /**
    * Return the form data. It accepts an optional options object with an `unflatten` parameter (defaults to `true`).
    * If you are only interested in the raw form data, pass `unflatten: false` to the handler
@@ -58,7 +60,6 @@ export interface FormHook<T extends FormData = FormData, I extends FormData = T>
   __updateFormDataAt: (field: string, value: unknown) => void;
   __updateDefaultValueAt: (field: string, value: unknown) => void;
   __readFieldConfigFromSchema: (field: string) => FieldConfig;
-  __getFieldDefaultValue: (path: string) => unknown;
 }
 
 export type FormSchema<T extends FormData = FormData> = {

--- a/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/context/processors_context.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/components/pipeline_editor/context/processors_context.tsx
@@ -151,7 +151,13 @@ export const PipelineProcessorsContextProvider: FunctionComponent<Props> = ({
           break;
         case 'managingProcessor':
           // These are the option names we get back from our UI
-          const knownOptionNames = Object.keys(processorTypeAndOptions.options);
+          const knownOptionNames = [
+            ...Object.keys(processorTypeAndOptions.options),
+            // We manually add fields that we **don't** want to be treated as "unknownOptions"
+            'internal_networks',
+            'internal_networks_field',
+          ];
+
           // The processor that we are updating may have options configured the UI does not know about
           const unknownOptions = omit(mode.arg.processor.options, knownOptionNames);
           // In order to keep the options we don't get back from our UI, we merge the known and unknown options


### PR DESCRIPTION
This is the suggestion I have for https://github.com/elastic/kibana/pull/103436

## Changes

### Expose `getFieldDefaultValue` on the `form`

Looking at the problem of the `isCustom` where you had to have a hack with a `useEffect` I decided to expose an existing handler from the form: `getFieldDefaultValue()`. This way we can know immediately the value of the `isCustom` state.

### Manually declare the known field

It seems that, to avoid declaring 2 fields manually when merging the data in `processors_context` file we had to use another hack inside the processor component (with `<UseMultiField />`). I went back to what we discussed over zoom and declared the 2 known fields. This simplified a lot the logic of the `NetworkDirection` component.